### PR TITLE
Update Detect-4 to include relevant message ID's and SQL query to retrieve from DB

### DIFF
--- a/defense-techniques/DETECT/DETECT-4/detect-4_description.md
+++ b/defense-techniques/DETECT/DETECT-4/detect-4_description.md
@@ -7,6 +7,7 @@ Monitor application deployment logs in the site's Audit Status Messages
 The following message ID's can be used to monitor application deployment:
 - 30226: Creation of application deployment
 - 30228: Deletion of application deployment
+
 The following SQL query can be run against the SCCM MSSQL database to retrieve these message types:
 ```
 select stat.*, ins.*, att1.*, stat.Time from v_StatusMessage as stat left join v_StatMsgInsStrings as ins on stat.RecordID = ins.RecordID left join v_StatMsgAttributes as att1 on stat.RecordID = att1.RecordID where stat.MessageType = 768 and stat.MessageID >= 30224 and stat.MessageID <= 30228 and stat.Time >= ##PRM:v_StatusMessage.Time## order by stat.Time desc

--- a/defense-techniques/DETECT/DETECT-4/detect-4_description.md
+++ b/defense-techniques/DETECT/DETECT-4/detect-4_description.md
@@ -4,10 +4,15 @@
 Monitor application deployment logs in the site's Audit Status Messages
 
 ## Summary
-
-
+The following message ID's can be used to monitor application deployment:
+- 30226: Creation of application deployment
+- 30228: Deletion of application deployment
+The following SQL query can be run against the SCCM MSSQL database to retrieve these message types:
+```
+select stat.*, ins.*, att1.*, stat.Time from v_StatusMessage as stat left join v_StatMsgInsStrings as ins on stat.RecordID = ins.RecordID left join v_StatMsgAttributes as att1 on stat.RecordID = att1.RecordID where stat.MessageType = 768 and stat.MessageID >= 30224 and stat.MessageID <= 30228 and stat.Time >= ##PRM:v_StatusMessage.Time## order by stat.Time desc
+```
 ## Associated Offensive IDs
 - [EXEC-1: Application deployment](../../../attack-techniques/EXEC/EXEC-1/exec-1_description.md)
 
 ## References
-Author, [Title](Link)
+Marshall Price, [SCCM Exploitation: Evading Defenses and Moving Laterally with SCCM Application Deployment](https://www.guidepointsecurity.com/blog/sccm-exploitation-evading-defenses-and-moving-laterally-with-sccm-application-deployment/)

--- a/defense-techniques/DETECT/DETECT-4/detect-4_description.md
+++ b/defense-techniques/DETECT/DETECT-4/detect-4_description.md
@@ -17,3 +17,4 @@ select stat.*, ins.*, att1.*, stat.Time from v_StatusMessage as stat left join v
 
 ## References
 Marshall Price, [SCCM Exploitation: Evading Defenses and Moving Laterally with SCCM Application Deployment](https://www.guidepointsecurity.com/blog/sccm-exploitation-evading-defenses-and-moving-laterally-with-sccm-application-deployment/)
+Microsoft, [Status and alert views in Configuration Manager](https://learn.microsoft.com/en-us/mem/configmgr/develop/core/understand/sqlviews/status-alert-views-configuration-manager)


### PR DESCRIPTION
This PR updates the Detect-4 page to add relevant message ID's which can be used to monitor application deployment and deletion. Additionally, it includes a sample SQL query to retrieve these message types from the SCCM MSSQL DB. 